### PR TITLE
feat: gerar imagem do personagem na criação e vincular a episódio (#34)

### DIFF
--- a/src/app/api/characters/[id]/references/route.ts
+++ b/src/app/api/characters/[id]/references/route.ts
@@ -26,7 +26,7 @@ export async function POST(
 ) {
   const { id } = await params;
   const body = await request.json();
-  const { image_url } = body;
+  const { image_url, approved } = body;
 
   if (!image_url) {
     return NextResponse.json(
@@ -37,7 +37,7 @@ export async function POST(
 
   const { data, error } = await supabase
     .from("character_references")
-    .insert({ character_id: id, image_url })
+    .insert({ character_id: id, image_url, approved: approved ?? false })
     .select()
     .single();
 

--- a/src/app/api/generate-image/route.ts
+++ b/src/app/api/generate-image/route.ts
@@ -5,11 +5,25 @@ import { supabase } from "@/lib/supabase";
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { shotId, prompt, referenceImageUrl, aspectRatio, strength } = body;
+    const {
+      shotId,
+      characterId,
+      prompt,
+      referenceImageUrl,
+      aspectRatio,
+      strength,
+    } = body;
 
-    if (!shotId || !prompt) {
+    if (!prompt) {
       return NextResponse.json(
-        { error: "shotId e prompt são obrigatórios" },
+        { error: "prompt é obrigatório" },
+        { status: 400 }
+      );
+    }
+
+    if (!shotId && !characterId) {
+      return NextResponse.json(
+        { error: "shotId ou characterId é obrigatório" },
         { status: 400 }
       );
     }
@@ -44,12 +58,38 @@ export async function POST(request: Request) {
       prompt: fullPrompt,
       referenceImageBase64,
       referenceImageMimeType,
-      aspectRatio: aspectRatio || "16:9",
+      aspectRatio: aspectRatio || "1:1",
     });
 
-    // Upload generated image to Supabase Storage
-    const fileName = `shots/${shotId}/${Date.now()}.png`;
     const imageBuffer = Buffer.from(result.imageBase64, "base64");
+
+    // Character image generation flow
+    if (characterId) {
+      const fileName = `characters/${characterId}/${Date.now()}.png`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("brahma-images")
+        .upload(fileName, imageBuffer, {
+          contentType: result.mimeType,
+          upsert: true,
+        });
+
+      if (uploadError) {
+        return NextResponse.json(
+          { error: `Erro no upload: ${uploadError.message}` },
+          { status: 500 }
+        );
+      }
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("brahma-images").getPublicUrl(fileName);
+
+      return NextResponse.json({ image_url: publicUrl });
+    }
+
+    // Shot image generation flow (existing behavior)
+    const fileName = `shots/${shotId}/${Date.now()}.png`;
 
     const { error: uploadError } = await supabase.storage
       .from("brahma-images")

--- a/src/app/characters/new/page.tsx
+++ b/src/app/characters/new/page.tsx
@@ -1,18 +1,70 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+
+interface Episode {
+  id: string;
+  title: string;
+  character_id: string;
+}
+
+interface Character {
+  id: string;
+  name: string;
+  prompt_base_en: string;
+}
+
+type Step = "form" | "generating" | "approval";
 
 export default function NewCharacter() {
   const router = useRouter();
+
+  // Form state
   const [name, setName] = useState("");
   const [age, setAge] = useState("");
   const [descriptionPt, setDescriptionPt] = useState("");
   const [promptBaseEn, setPromptBaseEn] = useState("");
   const [showPrompt, setShowPrompt] = useState(false);
+  const [selectedEpisodeId, setSelectedEpisodeId] = useState("");
+  const [episodes, setEpisodes] = useState<Episode[]>([]);
+
+  // Flow state
+  const [step, setStep] = useState<Step>("form");
   const [generating, setGenerating] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+
+  // Created character + generated image
+  const [createdCharacter, setCreatedCharacter] = useState<Character | null>(
+    null
+  );
+  const [generatedImageUrl, setGeneratedImageUrl] = useState("");
+
+  // Fetch all episodes (across all characters) for the optional link
+  useEffect(() => {
+    async function fetchEpisodes() {
+      try {
+        // Fetch all characters first, then their episodes
+        const charsRes = await fetch("/api/characters");
+        if (!charsRes.ok) return;
+        const chars: { id: string }[] = await charsRes.json();
+
+        const allEpisodes: Episode[] = [];
+        for (const char of chars) {
+          const res = await fetch(`/api/characters/${char.id}/episodes`);
+          if (res.ok) {
+            const eps = await res.json();
+            allEpisodes.push(...eps);
+          }
+        }
+        setEpisodes(allEpisodes);
+      } catch {
+        // Silently fail — episode select is optional
+      }
+    }
+    fetchEpisodes();
+  }, []);
 
   async function handleGeneratePrompt() {
     if (!name || !age || !descriptionPt) {
@@ -61,11 +113,11 @@ export default function NewCharacter() {
         description_pt: descriptionPt,
       };
 
-      // Send the prompt if user previewed/edited it
       if (showPrompt && promptBaseEn) {
         payload.prompt_base_en = promptBaseEn;
       }
 
+      // 1. Create the character
       const res = await fetch("/api/characters", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -77,7 +129,72 @@ export default function NewCharacter() {
         throw new Error(data.error || "Erro ao criar personagem");
       }
 
-      router.push("/");
+      const character: Character = await res.json();
+      setCreatedCharacter(character);
+
+      // 2. Link to episode if selected
+      if (selectedEpisodeId) {
+        await fetch(`/api/episodes/${selectedEpisodeId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ character_id: character.id }),
+        });
+      }
+
+      // 3. Generate character image
+      setStep("generating");
+      await generateCharacterImage(character);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro desconhecido");
+      setStep("form");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function generateCharacterImage(character: Character) {
+    setError("");
+    try {
+      const res = await fetch("/api/generate-image", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          characterId: character.id,
+          prompt: character.prompt_base_en,
+          aspectRatio: "1:1",
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Erro ao gerar imagem");
+      }
+
+      const data = await res.json();
+      setGeneratedImageUrl(data.image_url);
+      setStep("approval");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro desconhecido");
+      setStep("approval");
+    }
+  }
+
+  async function handleApprove() {
+    if (!createdCharacter || !generatedImageUrl) return;
+    setLoading(true);
+    setError("");
+
+    try {
+      await fetch(`/api/characters/${createdCharacter.id}/references`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          image_url: generatedImageUrl,
+          approved: true,
+        }),
+      });
+
+      router.push(`/characters/${createdCharacter.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro desconhecido");
     } finally {
@@ -85,6 +202,118 @@ export default function NewCharacter() {
     }
   }
 
+  async function handleRegenerate() {
+    if (!createdCharacter) return;
+    setStep("generating");
+    setGeneratedImageUrl("");
+    await generateCharacterImage(createdCharacter);
+  }
+
+  function handleSkip() {
+    if (!createdCharacter) return;
+    router.push(`/characters/${createdCharacter.id}`);
+  }
+
+  // --- Generating state ---
+  if (step === "generating") {
+    return (
+      <div className="max-w-2xl mx-auto text-center py-20">
+        <div className="animate-pulse mb-6">
+          <div className="w-24 h-24 bg-accent/20 rounded-full mx-auto flex items-center justify-center">
+            <svg
+              className="w-12 h-12 text-accent animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+          </div>
+        </div>
+        <h2 className="text-2xl font-bold mb-2">Gerando imagem...</h2>
+        <p className="text-muted">
+          O Brahma esta criando a imagem do personagem usando IA. Isso pode
+          levar alguns segundos.
+        </p>
+      </div>
+    );
+  }
+
+  // --- Approval state ---
+  if (step === "approval") {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold mb-2">Aprovar Imagem</h1>
+        <p className="text-muted mb-8">
+          Confira a imagem gerada para{" "}
+          <strong className="text-foreground">
+            {createdCharacter?.name}
+          </strong>
+          . Voce pode aprovar ou gerar novamente.
+        </p>
+
+        {error && (
+          <div className="bg-red-900/30 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
+            {error}
+          </div>
+        )}
+
+        {generatedImageUrl ? (
+          <div className="mb-8">
+            <div className="bg-card border border-border rounded-lg overflow-hidden">
+              <img
+                src={generatedImageUrl}
+                alt={`Imagem gerada de ${createdCharacter?.name}`}
+                className="w-full max-w-md mx-auto block"
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="bg-red-900/30 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
+            Falha ao gerar imagem. Tente novamente.
+          </div>
+        )}
+
+        <div className="flex gap-4">
+          {generatedImageUrl && (
+            <button
+              onClick={handleApprove}
+              disabled={loading}
+              className="bg-green-600 text-white font-semibold px-6 py-3 rounded-lg hover:bg-green-700 transition disabled:opacity-50 cursor-pointer"
+            >
+              {loading ? "Salvando..." : "Aprovar"}
+            </button>
+          )}
+          <button
+            onClick={handleRegenerate}
+            disabled={loading}
+            className="bg-accent text-black font-semibold px-6 py-3 rounded-lg hover:opacity-90 transition disabled:opacity-50 cursor-pointer"
+          >
+            Gerar Novamente
+          </button>
+          <button
+            onClick={handleSkip}
+            className="px-6 py-3 rounded-lg border border-border text-muted hover:text-foreground hover:border-foreground transition cursor-pointer"
+          >
+            Pular
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Form state ---
   return (
     <div className="max-w-2xl mx-auto">
       <h1 className="text-3xl font-bold mb-2">Novo Personagem</h1>
@@ -153,6 +382,33 @@ export default function NewCharacter() {
             detalhe, melhor a consistencia.
           </p>
         </div>
+
+        {episodes.length > 0 && (
+          <div>
+            <label
+              htmlFor="episode"
+              className="block text-sm font-medium mb-2"
+            >
+              Vincular a episodio (opcional)
+            </label>
+            <select
+              id="episode"
+              value={selectedEpisodeId}
+              onChange={(e) => setSelectedEpisodeId(e.target.value)}
+              className="w-full bg-card border border-border rounded-lg px-4 py-3 text-foreground focus:outline-none focus:border-accent transition"
+            >
+              <option value="">Nenhum</option>
+              {episodes.map((ep) => (
+                <option key={ep.id} value={ep.id}>
+                  {ep.title}
+                </option>
+              ))}
+            </select>
+            <p className="text-muted text-sm mt-2">
+              Selecione um episodio existente para vincular este personagem.
+            </p>
+          </div>
+        )}
 
         <div>
           <button


### PR DESCRIPTION
## Summary
- Refatora `/api/generate-image` para suportar geração de imagem de personagem (além de shots)
- Adiciona campo `approved` no POST de `character_references`
- Novo fluxo de criação de personagem: formulário → geração automática de imagem → tela de aprovação (Aprovar / Gerar Novamente / Pular)
- Select opcional de episódio existente para vincular ao personagem durante a criação

## Test plan
- [ ] Criar novo personagem com nome, idade e descrição
- [ ] Verificar que após clicar "Criar", a tela de loading aparece
- [ ] Verificar que a imagem gerada é exibida na tela de aprovação
- [ ] Testar botão "Aprovar" — imagem salva em `character_references` com `approved: true`
- [ ] Testar botão "Gerar Novamente" — nova imagem é gerada
- [ ] Testar botão "Pular" — redireciona para página do personagem sem salvar imagem
- [ ] Testar select de episódio — vincular personagem a episódio existente
- [ ] Verificar que o fluxo funciona sem episódios existentes (select não aparece)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)